### PR TITLE
Remove jetifier

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig debug.signingConfig
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,3 @@ org.gradle.jvmargs=-Xmx1536m
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
Hi, this small PR allow applications using this lib to [drop jetifier](https://adambennett.dev/2020/08/disabling-jetifier/).
I'm trying to drop jetifier in my application, and `flipper-android-no-op` is one of the last blocker.
Changes are without impact because this option seems unused in this lib.

Tested with local aar:

- before:
<img width="435" alt="Capture d’écran 2021-05-12 à 14 24 33" src="https://user-images.githubusercontent.com/22238882/117974634-152bed80-b32e-11eb-904a-e22b0dec747e.png">


- after : 
<img width="427" alt="Capture d’écran 2021-05-12 à 14 24 23" src="https://user-images.githubusercontent.com/22238882/117974653-1a893800-b32e-11eb-96f1-b03d33a8927c.png">


Plus, I added a debug `signingConfig` to test sample app in release mode.

I stay available to discuss about it if needed, and thanks for this useful library !