### PR TITLE
Add FlipperLeakEventListener

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.6.0'
-    ext.flipper_version = '0.177.0'
+    ext.flipper_version = '0.190.0'
     ext.soloader_version = '0.10.4'
 
     repositories {

--- a/flipperandroidnoop/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakEventListener.kt
+++ b/flipperandroidnoop/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakEventListener.kt
@@ -1,0 +1,5 @@
+package com.facebook.flipper.plugins.leakcanary2
+
+import leakcanary.EventListener
+
+class FlipperLeakEventListener : EventListener

--- a/flipperandroidnoop/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakListener.kt
+++ b/flipperandroidnoop/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakListener.kt
@@ -1,3 +1,4 @@
 package com.facebook.flipper.plugins.leakcanary2
 
+@Deprecated("Use FlipperLeakEventListener add to LeakCanary.config.eventListeners instead")
 class FlipperLeakListener

--- a/flipperandroidnoop/src/main/java/leakcanary/EventListener.kt
+++ b/flipperandroidnoop/src/main/java/leakcanary/EventListener.kt
@@ -1,0 +1,3 @@
+package leakcanary
+
+interface EventListener

--- a/flipperandroidnoop/src/main/java/leakcanary/LeakCanary.kt
+++ b/flipperandroidnoop/src/main/java/leakcanary/LeakCanary.kt
@@ -4,7 +4,9 @@ object LeakCanary {
 
   data class Config(
 
+    @Deprecated(message = "Add to LeakCanary.config.eventListeners instead")
     val onHeapAnalyzedListener: Any? = null
+    val eventListeners: List<EventListener> = listOf(),
 
   )
   @JvmStatic @Volatile

--- a/flipperandroidnoop/src/main/java/leakcanary/LeakCanary.kt
+++ b/flipperandroidnoop/src/main/java/leakcanary/LeakCanary.kt
@@ -5,8 +5,8 @@ object LeakCanary {
   data class Config(
 
     @Deprecated(message = "Add to LeakCanary.config.eventListeners instead")
-    val onHeapAnalyzedListener: Any? = null
-    val eventListeners: List<EventListener> = listOf(),
+    val onHeapAnalyzedListener: Any? = null,
+    val eventListeners: List<EventListener> = listOf()
 
   )
   @JvmStatic @Volatile


### PR DESCRIPTION
`FlipperLeakListener` is deprecated by Flipper and replaced with `FlipperLeakEventListener`. The no-op library needs to support this to prevent build errors.